### PR TITLE
WIP: Add more class instances for common types

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -24,7 +24,7 @@ dependencies:
 - base >= 4.7 && < 5
 - bound >= 2.0.0
 - elm-syntax >= 0.2.0 && < 0.2.1
-- generics-sop >= 0.4.0 && < 0.5.0
+- generics-sop >= 0.4.0 && < 0.6.0
 - protolude >= 0.2.3
 - text >= 1.2.0
 - time >= 1.8.0

--- a/package.yaml
+++ b/package.yaml
@@ -29,6 +29,7 @@ dependencies:
 - text >= 1.2.0
 - time >= 1.8.0
 - unordered-containers >= 0.2.8
+- uuid-types >= 1.0.0
 
 ghc-options:
   - -Wall

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.0
+resolver: lts-15.4
 packages:
 - .
 extra-deps:


### PR DESCRIPTION
This is a work-in-progress PR to get initial feedback.

Instances are added for the following Haskell types:

  * [x] `Map` (currently keys are forced to strings)
  * [x] `Set` (needs concrete instances for Elm primitive types)
  * [x] `NonEmpty`
  * [x] `UUID`

Before I finish this PR I will get #3 in a place where it can be merged and rebase this work on `master`.