### PR TITLE
Upgrade to LTS-21.22

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,6 +15,7 @@ jobs:
           - '9.0'
           - '9.2'
           - '9.4'
+          - '9.6'
         cabal-version: ['3.8.1.0']
     steps:
       # Checkout

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -143,3 +143,25 @@ jobs:
       - name: Cabal Test
         run: |
           cabal test all
+
+  stack-build:
+    name: Haskell Build (stack)
+    runs-on: ubuntu-latest # or macOS-latest, or windows-latest
+    strategy:
+      fail-fast: false
+    steps:
+      # Checkout
+      - uses: actions/checkout@v3
+        
+      # Setup
+      - name: Setup Haskell
+        uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          stack-version: latest
+
+      # Stack build
+      - name: Stack Bulid
+        run: |
+          stack build
+

--- a/haskell-to-elm.cabal
+++ b/haskell-to-elm.cabal
@@ -25,6 +25,7 @@ tested-with:
     , GHC == 9.0.2
     , GHC == 9.2.8
     , GHC == 9.4.8
+    , GHC == 9.6.3
 extra-source-files:
     README.md
     CHANGELOG.md

--- a/haskell-to-elm.cabal
+++ b/haskell-to-elm.cabal
@@ -18,7 +18,9 @@ license:        BSD-3-Clause
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.4.3, GHC == 8.6.5, GHC == 8.8.3
+    , GHC == 8.4.3
+    , GHC == 8.6.5
+    , GHC == 8.8.3
 extra-source-files:
     README.md
     CHANGELOG.md

--- a/haskell-to-elm.cabal
+++ b/haskell-to-elm.cabal
@@ -21,6 +21,10 @@ tested-with:
     , GHC == 8.4.3
     , GHC == 8.6.5
     , GHC == 8.8.3
+    , GHC == 8.10.7
+    , GHC == 9.0.2
+    , GHC == 9.2.8
+    , GHC == 9.4.8
 extra-source-files:
     README.md
     CHANGELOG.md

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
-resolver: lts-19.18
+resolver: lts-21.22
 packages:
 - .
 extra-deps:
-  - elm-syntax-0.3.2.0
+  - elm-syntax-0.3.3.0


### PR DESCRIPTION
This MR:

* Upgrades the resolver to lts-21.22
* Adds ghc 9.6 to the CI matrix (to test the upgrade in cabal-land)
* Adds a CI job for building with stack (to test the upgrade with stack)

The CI job for stack is pretty minimal, i.e. it doesn't do caching. I didn't have time to figure out the exact best incantation there. I'll try to get to that at some later time maybe.